### PR TITLE
Allow phosphorus links in generator

### DIFF
--- a/generator/index.html
+++ b/generator/index.html
@@ -77,8 +77,10 @@ function asset_url (md5) {
 }
 
 function id_from_url (url) {
-  if (url.indexOf("#") !== -1) url = url.slice(0, url.indexOf("#"));
-  var id = (url + " ").split(/[^0-9]+/)[1];
+  if(url.indexOf("phosphorus") <= url.indexOf("scratch")) {
+    if (url.indexOf("#") > url.indexOf("scratch")) url = url.slice(0, url.indexOf("#"));
+  }
+  var id = $.grep((url + " ").split(/[^0-9]+/), function (a) { return a !== ""}).slice(-1)[0];
   return id;
 }
 
@@ -343,7 +345,15 @@ $(document).ready(function () {
   input.addEventListener('input', function(e) {
     console.log(input.value);
     var id = id_from_url(input.value);
-    input.value = "http://scratch.mit.edu/projects/" + id;
+    if(id) {
+      if(input.value.indexOf("phosphorus") > input.value.indexOf("scratch")) {
+        input.value = "http://phosphorus.github.io/#" + id;
+      } else {
+        input.value = "http://scratch.mit.edu/projects/" + id;
+      }
+    } else {
+      input.value = "http://scratch.mit.edu/projects/";
+    }
     console.log(id);
   });
 

--- a/generator/index.html
+++ b/generator/index.html
@@ -77,10 +77,8 @@ function asset_url (md5) {
 }
 
 function id_from_url (url) {
-  if(url.indexOf("phosphorus") <= url.indexOf("scratch")) {
-    if (url.indexOf("#") > url.indexOf("scratch")) url = url.slice(0, url.indexOf("#"));
-  }
-  var id = $.grep((url + " ").split(/[^0-9]+/), function (a) { return a !== ""}).slice(-1)[0];
+  url = url.replace(/-[0-9]+/g, ''); // Remove numbers in comment anchors
+  var id = url.match(/[0-9]+(?![\s\S]*[0-9]+)/); // Find the last number in the url
   return id;
 }
 
@@ -345,15 +343,7 @@ $(document).ready(function () {
   input.addEventListener('input', function(e) {
     console.log(input.value);
     var id = id_from_url(input.value);
-    if(id) {
-      if(input.value.indexOf("phosphorus") > input.value.indexOf("scratch")) {
-        input.value = "http://phosphorus.github.io/#" + id;
-      } else {
-        input.value = "http://scratch.mit.edu/projects/" + id;
-      }
-    } else {
-      input.value = "http://scratch.mit.edu/projects/";
-    }
+    input.value = "http://scratch.mit.edu/projects/" + (id || '');
     console.log(id);
   });
 


### PR DESCRIPTION
Pretty self-explanatory. You should now be able to paste phosphorus links into the "generator" url input. I've tried as many scenarios as I can think of, and it seems to be holding up, but it might be worth trying to break it a couple of times before using. ;)

(This is a solution to https://github.com/tjvr/scratchblocks/issues/93)
