### PR TITLE
Fix and update help links

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <span class=author>v3.6.0 • by <a href="//tjvr.org">blob8108</a></span>
   </div>
   <span>
-    <a target="_blank" href="http://wiki.scratch.mit.edu/wiki/Block_Plugin/Syntax">help</a>
+    <a target="_blank" href="https://en.scratch-wiki.info/wiki/Block_Plugin/Syntax">help</a>
     <a href="http://github.com/tjvr/scratchblocks">github</a>
     <a href="/translator/" id="translate-link"><b>translate</b></a>
     <a href="/generator/"><b>generate</b></a>

--- a/v2/index.html
+++ b/v2/index.html
@@ -18,7 +18,7 @@
     <span class=author>by <a href="//tjvr.org">blob8108</a></span>
   </div>
   <span>
-    <a target="_blank" href="http://wiki.scratch.mit.edu/wiki/Block_Plugin/Syntax">help</a>
+    <a target="_blank" href="https://en.scratch-wiki.info/wiki/Block_Plugin/Syntax">help</a>
     <a href="//github.com/tjvr/scratchblocks/tree/css-v2">github</a>
     <a href="/generator/"><b>generate</b></a>
   </span>

--- a/v3.1/index.html
+++ b/v3.1/index.html
@@ -17,7 +17,7 @@
     <span class=author>v3.1 • by <a href="//tjvr.org">blob8108</a></span>
   </div>
   <span>
-    <a target="_blank" href="http://wiki.scratch.mit.edu/wiki/Block_Plugin/Syntax">help</a>
+    <a target="_blank" href="https://en.scratch-wiki.info/wiki/Block_Plugin/Syntax">help</a>
     <a href="http://github.com/tjvr/scratchblocks">github</a>
     <a href="/translator/" id="translate-link"><b>translate</b></a>
     <a href="/generator/"><b>generate</b></a>

--- a/v3.2/index.html
+++ b/v3.2/index.html
@@ -17,7 +17,7 @@
     <span class=author><b>v3.2</b> b1e2f040c • by <a href="//tjvr.org">blob8108</a></span>
   </div>
   <span>
-    <a target="_blank" href="http://wiki.scratch.mit.edu/wiki/Block_Plugin/Syntax">help</a>
+    <a target="_blank" href="https://en.scratch-wiki.info/wiki/Block_Plugin/Syntax">help</a>
     <a href="http://github.com/tjvr/scratchblocks">github</a>
     <a href="/generator/"><b>generate</b></a>
     <a href="/translator/" id="translate-link"><b>translate</b></a>

--- a/v3/index.html
+++ b/v3/index.html
@@ -17,7 +17,7 @@
     <span class=author>by <a href="//tjvr.org">blob8108</a></span>
   </div>
   <span>
-    <a target="_blank" href="http://wiki.scratch.mit.edu/wiki/Block_Plugin/Syntax">help</a>
+    <a target="_blank" href="https://en.scratch-wiki.info/wiki/Block_Plugin/Syntax">help</a>
     <a href="http://github.com/tjvr/scratchblocks">github</a>
     <a href="/generator/"><b>generate</b></a>
   </span>


### PR DESCRIPTION
The help links on the top of every page are outdated and have become broken, all redirecting to the [wrong wiki page](http://wiki.scratch.mit.edu/wiki/Block_Plugin/Syntax), as the Scratch Wiki [changed its domain several years ago](https://en.scratch-wiki.info/wiki/Scratch_Wiki#Server_Transfer). This PR fixes and updates these links to point to the new URL.